### PR TITLE
Explicitly define the encoding while reading CSV.

### DIFF
--- a/twstock/codes.py
+++ b/twstock/codes.py
@@ -24,7 +24,7 @@ twse = {}
 
 def read_csv(path, types):
     global codes, twse, tpex
-    with open(path, newline='', encoding='utf_8_sig') as csvfile:
+    with open(path, newline='', encoding='utf_8') as csvfile:
         reader = csv.reader(csvfile)
         csvfile.readline()
         for row in reader:

--- a/twstock/codes.py
+++ b/twstock/codes.py
@@ -24,7 +24,7 @@ twse = {}
 
 def read_csv(path, types):
     global codes, twse, tpex
-    with open(path, newline='') as csvfile:
+    with open(path, newline='', encoding='utf_8_sig') as csvfile:
         reader = csv.reader(csvfile)
         csvfile.readline()
         for row in reader:


### PR DESCRIPTION
The library throws the following error on windows which is caused by using system default encoding 'cp950'.
`UnicodeDecodeError: 'cp950' codec can't decode byte 0x8a in position 46: illegal multibyte sequence`