### PR TITLE
add an option to disable fetch_31() during init Stock

### DIFF
--- a/docs/reference/stock.rst
+++ b/docs/reference/stock.rst
@@ -59,11 +59,11 @@
 :class:`Stock`
 --------------
 
-.. class:: Stock(stock_id: str)
+.. class:: Stock(sid: str, initial_fetch: bool=True)
 
    有關股票歷史資訊 (開/收盤價，交易量，日期...etc) 以及簡易股票分析。
-   建立 :class:`Stock` 實例時，會自動呼叫 :meth:`fetch_31` 抓取近 31 日
-   之歷史股票資料。
+   建立 :class:`Stock` 實例時，若 ``initial_fetch`` 為 ``True`` (預設)，
+   會自動呼叫 :meth:`fetch_31` 抓取近 31 日之歷史股票資料。
 
 
    Class attributes are:

--- a/twstock/stock.py
+++ b/twstock/stock.py
@@ -122,14 +122,15 @@ class TPEXFetcher(BaseFetcher):
 
 class Stock(analytics.Analytics):
 
-    def __init__(self, sid: str):
+    def __init__(self, sid: str, initial_fetch: bool=True):
         self.sid = sid
         self.fetcher = TWSEFetcher() if codes[sid].market == '上市' else TPEXFetcher()
         self.raw_data = []
         self.data = []
 
         # Init data
-        self.fetch_31()
+        if initial_fetch:
+            self.fetch_31()
 
     def _month_year_iter(self, start_month, start_year, end_month, end_year):
         ym_start = 12 * start_year + start_month - 1


### PR DESCRIPTION
1. It's a bad idea to send requests in `__init__()`
2. `fetch_31()` is a strange method and it sends too many requests (3 in the worst case)
3. In most cases, I want to get the data in a specific month or date, so I don't need the initial `fetch_31()` and want to fully control what requests I will send

Therefore, I add an option to disable the initial `fetch_31()`, and leave the default behavior the same as in the original implementation.