### PR TITLE
Strip all fields for StockCodeInfo

### DIFF
--- a/twstock/codes.py
+++ b/twstock/codes.py
@@ -29,11 +29,12 @@ def read_csv(path, types):
         csvfile.readline()
         for row in reader:
             row = ROW(*row)
-            codes[row.code] = row
+            code = row.code.strip()
+            codes[code] = row
             if types == 'tpex':
-                tpex[row.code] = row
+                tpex[code] = row
             else:
-                twse[row.code] = row
+                twse[code] = row
 
 
 read_csv(TPEX_EQUITIES_CSV_PATH, 'tpex')

--- a/twstock/codes.py
+++ b/twstock/codes.py
@@ -28,13 +28,12 @@ def read_csv(path, types):
         reader = csv.reader(csvfile)
         csvfile.readline()
         for row in reader:
-            row = ROW(*row)
-            code = row.code.strip()
-            codes[code] = row
+            row = ROW(*(item.strip() for item in row))
+            codes[row.code] = row
             if types == 'tpex':
-                tpex[code] = row
+                tpex[row.code] = row
             else:
-                twse[code] = row
+                twse[row.code] = row
 
 
 read_csv(TPEX_EQUITIES_CSV_PATH, 'tpex')


### PR DESCRIPTION
Some codes in the CSV files has white space after the codes, 4148 for example:
`股票,4148      ,全宇生技-KY,KYG0232P1072,2017/06/08,上市,生技醫療業,ESVUFR`
in the `twse_equities.csv`.
Because of this, `Stock('4148')` cannot get the correct result.
It's actually a problem in the original CSV files, but I don't know where you got them, so I don't change them.

It would be better to validate and handle all the values in the files or the data we fetch.
Because I actually have my own database for the stock information, I only do a workaround here so that I can use `Stock()`.