### PR TITLE
add proxy-provider callback

### DIFF
--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -1,0 +1,29 @@
+import unittest
+
+from twstock.proxy import get_proxies, configure_proxy_provider, reset_proxy_provider
+
+
+def _fake_provider():
+    return dict(http="http-proxy", https="https-proxy")
+
+
+class ProxyProviderTest(unittest.TestCase):
+
+    def setUp(self):
+        reset_proxy_provider()
+
+    def tearDown(self):
+        reset_proxy_provider()
+
+    def test_configure(self):
+        # default values are empty
+        self.assertDictEqual({}, get_proxies())
+
+        # configure fake proxy
+        configure_proxy_provider(_fake_provider)
+        self.assertEqual("http-proxy", get_proxies()['http'])
+        self.assertEqual("https-proxy", get_proxies()['https'])
+
+        # reset proxy
+        reset_proxy_provider()
+        self.assertDictEqual({}, get_proxies())

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -1,10 +1,7 @@
 import unittest
 
 from twstock.proxy import get_proxies, configure_proxy_provider, reset_proxy_provider
-
-
-def _fake_provider():
-    return dict(http="http-proxy", https="https-proxy")
+from twstock.proxy import SingleProxyProvider
 
 
 class ProxyProviderTest(unittest.TestCase):
@@ -20,7 +17,7 @@ class ProxyProviderTest(unittest.TestCase):
         self.assertDictEqual({}, get_proxies())
 
         # configure fake proxy
-        configure_proxy_provider(_fake_provider)
+        configure_proxy_provider(SingleProxyProvider(dict(http="http-proxy", https="https-proxy")))
         self.assertEqual("http-proxy", get_proxies()['http'])
         self.assertEqual("https-proxy", get_proxies()['https'])
 

--- a/twstock/codes/fetch.py
+++ b/twstock/codes/fetch.py
@@ -13,6 +13,7 @@ from collections import namedtuple
 import requests
 from lxml import etree
 
+from twstock.proxy import get_proxies
 
 TWSE_EQUITIES_URL = 'http://isin.twse.com.tw/isin/C_public.jsp?strMode=2'
 TPEX_EQUITIES_URL = 'http://isin.twse.com.tw/isin/C_public.jsp?strMode=4'
@@ -26,7 +27,7 @@ def make_row_tuple(typ, row):
 
 
 def fetch_data(url):
-    r = requests.get(url)
+    r = requests.get(url, proxies=get_proxies())
     root = etree.HTML(r.text)
     trs = root.xpath('//tr')[1:]
 

--- a/twstock/proxy.py
+++ b/twstock/proxy.py
@@ -1,20 +1,38 @@
-def _no_proxy_configurer():
-    return {}
+import abc
 
 
-_provider = _no_proxy_configurer
+class ProxyProvider(abc.ABC):
+    @abc.abstractmethod
+    def get_proxy(self):
+        return NotImplemented
+
+
+class NoProxyProvier(ProxyProvider):
+    def get_proxy(self):
+        return {}
+
+
+class SingleProxyProvider(ProxyProvider):
+    def __init__(self, proxy=None):
+        self._proxy = proxy
+
+    def get_proxy(self):
+        return self._proxy
+
+
+_provider_instance = NoProxyProvier()
 
 
 def reset_proxy_provider():
-    configure_proxy_provider(_no_proxy_configurer)
+    configure_proxy_provider(NoProxyProvier())
 
 
-def configure_proxy_provider(provider_callback):
-    global _provider
-    if not callable(provider_callback):
-        raise BaseException("proxy provider should be a callable type")
-    _provider = provider_callback
+def configure_proxy_provider(provider_instance):
+    global _provider_instance
+    if not isinstance(provider_instance, ProxyProvider):
+        raise BaseException("proxy provider should be a ProxyProvider object")
+    _provider_instance = provider_instance
 
 
 def get_proxies():
-    return _provider()
+    return _provider_instance.get_proxy()

--- a/twstock/proxy.py
+++ b/twstock/proxy.py
@@ -1,0 +1,20 @@
+def _no_proxy_configurer():
+    return {}
+
+
+_provider = _no_proxy_configurer
+
+
+def reset_proxy_provider():
+    configure_proxy_provider(_no_proxy_configurer)
+
+
+def configure_proxy_provider(provider_callback):
+    global _provider
+    if not callable(provider_callback):
+        raise BaseException("proxy provider should be a callable type")
+    _provider = provider_callback
+
+
+def get_proxies():
+    return _provider()

--- a/twstock/realtime.py
+++ b/twstock/realtime.py
@@ -7,6 +7,7 @@ import requests
 import twstock
 import sys
 
+from twstock.proxy import get_proxies
 
 SESSION_URL = 'http://mis.twse.com.tw/stock/index.jsp'
 STOCKINFO_URL = 'http://mis.twse.com.tw/stock/api/getStockInfo.jsp?ex_ch={stock_id}&_={time}'
@@ -67,7 +68,7 @@ def _join_stock_id(stocks) -> str:
 
 def get_raw(stocks) -> dict:
     req = requests.Session()
-    req.get(SESSION_URL)
+    req.get(SESSION_URL, proxies=get_proxies())
 
     r = req.get(
         STOCKINFO_URL.format(

--- a/twstock/stock.py
+++ b/twstock/stock.py
@@ -3,6 +3,9 @@
 import datetime
 import urllib.parse
 from collections import namedtuple
+
+from twstock.proxy import get_proxies
+
 try:
     from json.decoder import JSONDecodeError
 except ImportError:
@@ -48,7 +51,7 @@ class TWSEFetcher(BaseFetcher):
     def fetch(self, year: int, month: int, sid: str, retry: int=5):
         params = {'date': '%d%02d01' % (year, month), 'stockNo': sid}
         for retry_i in range(retry):
-            r = requests.get(self.REPORT_URL, params=params)
+            r = requests.get(self.REPORT_URL, params=params, proxies=get_proxies())
             try:
                 data = r.json()
             except JSONDecodeError:
@@ -92,7 +95,7 @@ class TPEXFetcher(BaseFetcher):
     def fetch(self, year: int, month: int, sid: str, retry: int=5):
         params = {'d': '%d/%d' % (year - 1911, month), 'stkno': sid}
         for retry_i in range(retry):
-            r = requests.get(self.REPORT_URL, params=params)
+            r = requests.get(self.REPORT_URL, params=params, proxies=get_proxies())
             try:
                 data = r.json()
             except JSONDecodeError:


### PR DESCRIPTION
This patch is not same with #53 https://github.com/mlouielu/twstock/pull/54 which is for end-user cli and class, mine is for requests configuration.

In my point of view, a dynamic proxy provider is better than static configurations. the program might be banned when it fetches brunch of data (eg. fetch 2330 from 2015 ~ 2018). It'd be very nice with a programmable proxy configuration.


Benefits:

* test cases are simple. it only needs to check the proxy provider is configured or not
* modification is focused on `requests.get` and `requests.Session.get`
* it is possible to downland lots of data with proxies in round robin

