### PR TITLE
Note for the prefetch behavior of Stock object

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ twstock.realtime.get('2330')    # 擷取當前台積電股票資訊
 twstock.realtime.get(['2330', '2337', '2409'])  # 擷取當前三檔資訊
 ```
 
+## 節省 http request
+
+Stock 物件在初始化時，預設的行為會抓取近 31 個交易日的資料。實作上會由今日往前算 60 天，因此每建立一個 Stock 物件，會打 3 個 http request。若想避免這個行為，可設定初始參數：
+
+```py
+import twstock
+
+# 不執行預抓交易資料
+twstock.Stock('1240', initial_fetch=False)
+```
+
 
 ## 使用範例
 


### PR DESCRIPTION
I found each Stock making extra http-request while it was initializing.

```py
import twstock
import requests
import time

ORIGIN_GET = requests.get


def hijack_get(url, params=None, **kwargs):
    time.sleep(2)
    print("get: {}, params={}, kwargs={}".format(url, params, kwargs))
    return ORIGIN_GET(url, params, **kwargs)


def main():
    requests.get = hijack_get
    try:
        twstock.Stock('2330')
    finally:
        requests.get = ORIGIN_GET


if __name__ == '__main__':
    main()

```

```
get: http://www.twse.com.tw/exchangeReport/STOCK_DAY, params={'date': '20190301', 'stockNo': '2330'}, kwargs={'proxies': {}}
get: http://www.twse.com.tw/exchangeReport/STOCK_DAY, params={'date': '20190401', 'stockNo': '2330'}, kwargs={'proxies': {}}
get: http://www.twse.com.tw/exchangeReport/STOCK_DAY, params={'date': '20190501', 'stockNo': '2330'}, kwargs={'proxies': {}}
```

The initialization behavior was not needed to developers who designed an application to fetch lots of history data. It might be nice to mind the useful tips in the document.

I found that tips in https://github.com/mlouielu/twstock/pull/31 and made a patch to document.